### PR TITLE
Max andy user login

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,11 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :image, :password, :password_confirmation)
+    params.require(:user).permit(:name,
+                                 :email,
+                                 :image,
+                                 :password,
+                                 :password_confirmation,
+                                 :phone)
   end
 end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -5,7 +5,7 @@
         <h4>Join the Stack Overflow Community</h4><br>
         <p>Stack Overflow is a community of 6.9 million programmers, just like you, helping each other.</p>
         <p>Join them; it only takes a minute:</p>
-        <div class="center"><%= button_to "Sign Up", new_user_path, method: "get", class: "waves-effect blue darken-1 waves-light btn-large" %></div>
+        <div class="center"><%= button_to "Create Account", new_user_path, method: "get", class: "waves-effect blue darken-1 waves-light btn-large" %></div>
       </span>
     </div>
   </div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -6,7 +6,7 @@
     </ul>
     <ul id="nav-mobile" class="right">
       <li><a href="/login" class="black-text">Login</a></li>
-      <li><a class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
+      <li><a href="/users/new" class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
     </ul>
   </div>
 </nav>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,8 +8,8 @@
             <%=  f.text_field :name%>
             <%=  f.label :email %>
             <%=  f.email_field :email %>
-            <%=  f.label :image %>
-            <%=  f.file_field :image %>
+            <%=  f.label :phone %>
+            <%=  f.telephone_field :phone %>
             <%=  f.label :password %>
             <%=  f.password_field :password %>
             <%=  f.label :password_confirmation %>
@@ -20,4 +20,3 @@
     </div>
   </div>
 </div>
-

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ class Seed
   def generate_categories
     puts "Generating Categories"
     20.times do |i|
-      Category.create!(name: Faker::Hipster.word)
+      Category.create!(name: Faker::Hipster.unique.word)
       puts "Generated Category: #{Category.last.name}"
     end
   end

--- a/spec/features/guests/guest_creates_account_spec.rb
+++ b/spec/features/guests/guest_creates_account_spec.rb
@@ -4,7 +4,7 @@ feature 'when a guest visits the root page' do
   scenario 'guest creates account' do
     visit root_path
 
-    click_on "Sign Up"
+    click_on "Create Account"
 
     expect(current_path).to eq(new_user_path)
 
@@ -15,6 +15,5 @@ feature 'when a guest visits the root page' do
     fill_in "Password confirmation", with: "seekrit"
 
     expect { click_on "Create Account"}.to change(User, :count).by(1)
-    byebug
   end
 end

--- a/spec/features/guests/guest_creates_account_spec.rb
+++ b/spec/features/guests/guest_creates_account_spec.rb
@@ -10,9 +10,11 @@ feature 'when a guest visits the root page' do
 
     fill_in "Name", with: "Smile Warbler"
     fill_in "Email", with: "smile@warbler.com"
+    fill_in "Phone", with: "123-456-7890"
     fill_in "Password", with: "seekrit"
     fill_in "Password confirmation", with: "seekrit"
 
     expect { click_on "Create Account"}.to change(User, :count).by(1)
+    byebug
   end
 end

--- a/spec/features/users/user_logs_in_spec.rb
+++ b/spec/features/users/user_logs_in_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 feature 'user visits root' do
-  scenario 'user logs in' do
+  scenario 'user logs in successfully' do
     user = Fabricate(:user, password: 'password')
 
     visit '/'
@@ -15,5 +15,22 @@ feature 'user visits root' do
 
     click_button "Login"
     expect(current_path).to eq(user_path(user))
+  end
+
+  scenario 'user login fails' do
+    user = Fabricate(:user, password: 'password')
+
+    visit '/'
+
+    click_link 'Login'
+
+    expect(current_path).to eq(login_path)
+
+    fill_in "Name", with: "#{user.name}"
+    fill_in "Password", with: "bad_password"
+
+    click_button "Login"
+    expect(current_path).to eq(login_path)
+    expect(page).to have_content("Invalid Credentials")
   end
 end


### PR DESCRIPTION
changes text on central 'sign up'
button to read 'create account';
spec test is now passing.
Adds sad path test for failed
login.
Removes image field form user account
creation and adds a telephone_field.
Test modified to test same and is
passing appropriately.
Fix broken sign-up button in navbar
Makes category names for seeds unique
changes text on central 'sign up'
button to read 'create account';
spec test is now passing.
Catching up with master