### PR TITLE
Ryan fix recent activity header

### DIFF
--- a/app/models/presenter.rb
+++ b/app/models/presenter.rb
@@ -11,4 +11,8 @@ class Presenter
       Question.order_by_update.first(25)
     end
   end
+
+  def category_name(id)
+    Category.find(id).name
+  end
 end

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -37,7 +37,11 @@
         <div class="card white">
           <div class="card-content black-text">
             <div class="recent-activity">
-            <span class="card-title">Recent Activity</span>
+              <% if params[:category].nil? %>
+                <span class="card-title">Recent Activity</span>
+              <% else %>
+                <span class="card-title">Recent Activity: <%=@presenter.category_name(params[:category]) %> </span>
+              <% end %>
               <table class="bordered">
                 <thead>
                   <tr>

--- a/spec/features/guests/guest_visits_root_spec.rb
+++ b/spec/features/guests/guest_visits_root_spec.rb
@@ -61,6 +61,11 @@ feature 'when a guest visits the root page' do
 
     expect(current_path).to eq(root_path)
 
+    within('.recent-activity') do
+      expect(page).to have_content("Software")
+      expect(page).to_not have_content("Physics")
+    end
+
     within('.root-questions') do
       expect(page).to have_content("What is?")
 


### PR DESCRIPTION
Adds a recent activity header that responds to which category has been clicked on the root page.