### PR TITLE
Kf gravatar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'kaminari'
 gem 'uuid'
 gem 'figaro'
 gem 'twilio-ruby'
+gem 'gravatar_image_tag'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,7 @@ GEM
       thor (~> 0.14)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
+    gravatar_image_tag (1.2.0)
     i18n (0.8.1)
     jbuilder (2.6.3)
       activesupport (>= 3.0.0, < 5.2)
@@ -242,6 +243,7 @@ DEPENDENCIES
   fabrication
   faker
   figaro
+  gravatar_image_tag
   jbuilder (~> 2.5)
   jquery-rails
   kaminari

--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -35,3 +35,14 @@ a.collection-item {
 .error {
   color: red;
 }
+
+.user-pic {
+  padding: 10px;
+  margin:auto;
+  display: block;
+}
+
+.user-name {
+  padding: 10px;
+  text-align: center;
+}

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -12,14 +12,6 @@
           <tbody>
             <tr>
               <td>
-                Name:
-              </td>
-              <td>
-                <%= current_user.name %>
-              </td>
-            </tr>
-            <tr>
-              <td>
                 E-Mail:
               </td>
               <td>
@@ -57,9 +49,13 @@
     </div>
   </div>
   <div class="col s12 m6">
-    <div class="card" id='user-avatar'>
-      <div class="card-image">
-        <img src="https://robohash.org/<%= current_user.name%>" height="412.75" width="287">
+    <div class="card blue lighten-1" id='user-avatar'>
+      <div>
+      <%= gravatar_image_tag @user.email, alt: @user.name, gravatar: { size: 200, default: "http://www.ulyces.co/wp-content/plugins/tia-author-image/default_user_icon.jpg" }, class: "user-pic" %>
+      <hr>
+        <div class="user-name" >
+          Name: <%= current_user.name %>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -6,7 +6,7 @@
         <%= form_for(@user) do |f| %>
             <%=  f.label :name %>
             <%=  f.text_field :name%>
-            <%=  f.label :email %>
+            <%=  f.label :email, "Email (will be used for Gravatar if applicable)" %>
             <%=  f.email_field :email %>
             <%=  f.label :phone %>
             <%=  f.telephone_field :phone %>

--- a/config/initializers/gravatar_image_tag.rb
+++ b/config/initializers/gravatar_image_tag.rb
@@ -1,0 +1,3 @@
+GravatarImageTag.configure do |config|
+  config.default_image = "http://www.ulyces.co/wp-content/plugins/tia-author-image/default_user_icon.jpg" 
+end

--- a/spec/features/users/user_views_their_profile_spec.rb
+++ b/spec/features/users/user_views_their_profile_spec.rb
@@ -14,10 +14,13 @@ feature 'user profile' do
     expect(page).to have_css('#user-info')
 
     within('#user-info-table') do
-      expect(page).to have_content(user.name)
       expect(page).to have_content(user.email)
       expect(page).to have_content(user.phone)
       expect(page).to have_content('Reputation')
+    end
+
+    within('#user-avatar') do
+      expect(page).to have_content(user.name)
     end
   end
 


### PR DESCRIPTION
This adds the gravatar_image gem so we can target users' gravatars via their email address. If their email is linked to a gravatar, their avatar will be updated. If they don't have gravatar, they are assigned a default image. This includes some changes to the user show page because the image size was off when it was populated with an actual image. I changed the styling to try to make it more proportional, including moving the user's name below their image, which I like because the rest of the info (on the left, email, phone, reputation) can be edited, while name cannot.