### PR TITLE
User can delete answer

### DIFF
--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -36,7 +36,7 @@ private
     return true if controller == "home"
     return true if controller == "users" && action.in?(%w(show edit update))
     return true if controller == "questions" && action.in?(%w(index show new create destroy edit update))
-    return true if controller == "answers" && action.in?(%w(create))
+    return true if controller == "answers" && action.in?(%w(create destroy))
     return true if controller == "comments" && action.in?(%w(create))
     return true if controller == "passwords" && action.in?(%w(edit update))
   end

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -61,8 +61,10 @@
                 <p>Author: <%= answer.find_user %> Updated: <%= answer.updated_at.strftime("%D at %r") unless answer.updated_at.nil? %></p><br>
                 <br>
               </div>
-              <div id='answer-delete-button-admin' class='left card-action'>
-                <% if current_admin? %>
+              <div id='answer-delete-button' class='left card-action'>
+                <% if current_users_question?(@question) %>
+                  <%= button_to "Delete Answer","/answers/#{answer.id}", method: :delete, params: { id: answer.id}, class: "right red darken-4 btn-small" %></br>
+                <% elsif current_admin? %>
                   <%= button_to "Delete Answer","/answers/#{answer.id}", method: :delete, params: { id: answer.id}, class: "right red darken-4 btn-small" %></br>
                 <% end %>
               </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(version: 20170401190122) do
     t.text     "body"
     t.integer  "user_id"
     t.integer  "category_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["category_id"], name: "index_questions_on_category_id", using: :btree
     t.index ["user_id"], name: "index_questions_on_user_id", using: :btree
   end

--- a/spec/features/admin/admin_can_delete_posts_spec.rb
+++ b/spec/features/admin/admin_can_delete_posts_spec.rb
@@ -18,11 +18,11 @@ feature 'admin can delete posts' do
 
       visit question_path(question)
 
-      first('#answer-delete-button-admin').click_button('Delete Answer')
+      first('#answer-delete-button').click_button('Delete Answer')
 
       expect(current_path).to eq(question_path(question))
 
-      expect(page).to_not have_css('#answer-delete-button-admin')
+      expect(page).to_not have_css('#answer-delete-button')
       expect(question.answers.count).to eq(0)
       expect(Comment.count).to eq(1)
       expect(Comment.first.commentable_type).to eq('Question')

--- a/spec/features/users/user_can_delete_an_answer_spec.rb
+++ b/spec/features/users/user_can_delete_an_answer_spec.rb
@@ -11,7 +11,7 @@ feature 'user can delete an answer' do
                                       user: user)
 
     answer = question.answers.create(body: "BlessUp", user: user)
-    answer_comment = answer.comments.create(body: "DJKhaled")
+    answer_comment = answer.comments.create(body: "DJKhaled", user: user)
     question_comment = question.comments.create(body: "Gratitude", user: user)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
@@ -30,5 +30,33 @@ feature 'user can delete an answer' do
     expect(question.answers.count).to eq(0)
     expect(Comment.count).to eq(1)
     expect(Comment.first.commentable_type).to eq('Question')
+  end
+    scenario 'user does not own an answer and cannot see "Delete Answer"' do
+    user_1 = Fabricate(:user, id: 1, name: "we_the_best")
+    user_1.roles.create(name: 'registered_user')
+    
+    user_2 = Fabricate(:user, id: 2, name: "we_the_best")
+    user_2.roles.create(name: 'registered_user')
+
+    question = Fabricate(:question,
+                                      title: "Why are we the best?",
+                                      body: "They're trying to stop us.",
+                                      user: user_1)
+
+    answer = question.answers.create(body: "BlessUp", user: user_1)
+    answer_comment = answer.comments.create(body: "DJKhaled", user: user_1)
+    question_comment = question.comments.create(body: "Gratitude", user: user_1)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_2)
+
+    visit question_path(question)
+    expect(current_path).to eq(question_path(question))
+
+    within(".question-answers .question-answer:nth-child(1)") do
+      expect(page).to have_content("BlessUp")
+    end
+
+    expect(page).to_not have_content('Delete Answer')
+    expect(question.answers.count).to eq(1)
   end
 end

--- a/spec/features/users/user_can_delete_an_answer_spec.rb
+++ b/spec/features/users/user_can_delete_an_answer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+feature 'user can delete an answer' do
+  scenario 'user owns an answer and clicks "Delete Answer"' do
+    user = Fabricate(:user, id: 1, name: "we_the_best")
+    user.roles.create(name: 'registered_user')
+
+    question = Fabricate(:question,
+                                      title: "Why are we the best?",
+                                      body: "They're trying to stop us.",
+                                      user: user)
+
+    answer = question.answers.create(body: "BlessUp", user: user)
+    answer_comment = answer.comments.create(body: "DJKhaled")
+    question_comment = question.comments.create(body: "Gratitude", user: user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+    within(".question-answers .question-answer:nth-child(1)") do
+      expect(page).to have_content("BlessUp")
+    end
+
+    first('#answer-delete-button').click_button('Delete Answer')
+
+    expect(current_path).to eq(question_path(question))
+
+    expect(page).to_not have_css('#answer-delete-button')
+    expect(question.answers.count).to eq(0)
+    expect(Comment.count).to eq(1)
+    expect(Comment.first.commentable_type).to eq('Question')
+  end
+end


### PR DESCRIPTION
Builds test for whether or not a user can delete a question they own.
Modifies the button css class from 'answer-delete-button-admin' to
'answer-delete-button' to avoid redundancy. Admin tests modified to target this css.
All tests passing. Test also includes ensuring dependent destroy for an answers comments
and doesn't destroy a questions comments.

Adds sad path testing to user can delete question:
If the user doesn't own the question, they do not see the Delete Answer button.
Also noting that I added destroy answer  to registered user permissions.

All tests passing with 98.4% coverage. 