### PR TITLE
Admin bans user features; closes#17

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,11 @@ class ApplicationController < ActionController::Base
 
   def authorize!
     unless authorized?
-      flash[:danger] = "You are not authorized to do that. Please log in or create an account."
+      if current_user && current_user.blocked_user?
+        flash[:danger] = "Your account priveleges have been limited due to your activity"
+      else
+        flash[:danger] = "You are not authorized to do that. Please log in or create an account."
+      end
       redirect_to root_path
     end
   end

--- a/app/controllers/user_permissions_controller.rb
+++ b/app/controllers/user_permissions_controller.rb
@@ -2,7 +2,11 @@ class UserPermissionsController < ApplicationController
 
   def update
     user = User.find(params[:id])
-    user.deactivate
+    if user.registered_user?
+      user.deactivate
+    else
+      user.reactivate
+    end
     redirect_to request.referrer
   end
 end

--- a/app/controllers/user_permissions_controller.rb
+++ b/app/controllers/user_permissions_controller.rb
@@ -2,10 +2,7 @@ class UserPermissionsController < ApplicationController
 
   def update
     user = User.find(params[:id])
-    user.user_roles.destroy_all
-    user.save
-    user.roles.create(name: 'blocked_user')
-    user.save
+    user.deactivate
     redirect_to request.referrer
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,9 +29,18 @@ class User < ApplicationRecord
     roles.exists?(name: "registered_user")
   end
 
+  def blocked_user?
+    roles.exists?(name: "blocked_user")
+  end
+
   def deactivate
     user_roles.destroy_all
-    user_roles.create(role: Role.find_by(name: 'blocked_user'))
+    user_roles.create(role: Role.find_by(name: "blocked_user"))
+  end
+
+  def reactivate
+    user_roles.destroy_all
+    user_roles.create(role: Role.find_by(name: "registered_user"))
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,4 +29,9 @@ class User < ApplicationRecord
     roles.exists?(name: "registered_user")
   end
 
+  def deactivate
+    user_roles.destroy_all
+    user_roles.create(role: Role.find_by(name: 'blocked_user'))
+  end
+
 end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -4,7 +4,8 @@ class Permission
   attr_reader :user, :controller, :action
 
   def_delegators :user, :registered_user?,
-                        :admin?
+                        :admin?,
+                        :blocked_user?
 
   def initialize(user)
     @user = user || User.new
@@ -17,6 +18,8 @@ class Permission
       admin_permissions
     elsif registered_user?
       registered_user_permissions
+    elsif blocked_user?
+      blocked_user_permissions
     else
       guest_permissions
     end
@@ -32,20 +35,29 @@ private
   end
 
   def registered_user_permissions
-    return true if controller == "sessions"
-    return true if controller == "home"
     return true if controller == "users" && action.in?(%w(show edit update))
     return true if controller == "questions" && action.in?(%w(index show new create destroy edit update))
     return true if controller == "answers" && action.in?(%w(create))
     return true if controller == "comments" && action.in?(%w(create))
     return true if controller == "passwords" && action.in?(%w(edit update))
+    basic_permissions
+  end
+
+  def blocked_user_permissions
+    return true if controller == "users" && action.in?(%w(show edit update))
+    return true if controller == "questions" && action.in?(%w(index show))
+    return true if controller == "passwords" && action.in?(%w(edit update))
+    basic_permissions
   end
 
   def guest_permissions
-    return true if controller == "sessions"
-    return true if controller == "home"
     return true if controller == "users" && action.in?(%w(new create show))
     return true if controller == "questions" && action.in?(%w(index show))
+    basic_permissions
   end
 
+  def basic_permissions
+    return true if controller == "sessions"
+    return true if controller == "home"
+  end
 end

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,7 +1,11 @@
 <h2>Question</h2>
-<% if current_admin? %>
+<% if current_admin? && @question.user.registered_user? %>
   <div id='deactivate-user-button' class='right card-action'>
     <%= button_to "Deactivate User", user_permission_path(@question.user), method: :put, class: "waves-effect red darken-1 waves-light btn right" %>
+  </div>
+<% elsif current_admin? && @question.user.blocked_user? %>
+  <div id='reactivate-user-button' class='right card-action'>
+    <%= button_to "Reactivate User", user_permission_path(@question.user), method: :put, class: "waves-effect red darken-1 waves-light btn right" %>
   </div>
 <% end %>
 <div class="row">

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,8 +55,8 @@ ActiveRecord::Schema.define(version: 20170401190122) do
     t.text     "body"
     t.integer  "user_id"
     t.integer  "category_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["category_id"], name: "index_questions_on_category_id", using: :btree
     t.index ["user_id"], name: "index_questions_on_user_id", using: :btree
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,6 +15,7 @@ class Seed
   def generate_roles
     Role.create(name: 'registered_user')
     Role.create(name: 'admin')
+    Role.create(name: 'blocked_user')
     puts "Generated registered_user and admin roles"
   end
 
@@ -42,7 +43,7 @@ class Seed
   def generate_user_questions
     User.all.each do |user|
       5.times do |i|
-        user.questions.create!(title:   Faker::Hipster.sentence,
+        user.questions.create!(title:   Faker::Hipster.sentence(5),
                               body:     Faker::Hipster.paragraph,
                               category: Category.find(Random.new.rand(1..20)))
         puts "Generated Question #{user.questions.count} for #{user.name}"
@@ -82,7 +83,7 @@ class Seed
                 password:  "password",
                 phone:     Faker::Base.numerify('###-###-####'),
                 image:     Faker::Avatar.image)
-    User.last.user_roles.create(role: Role.last)
+    User.last.user_roles.create(role: Role.find_by(name: 'admin'))
     puts "Generated #{User.last.name} as #{User.last.roles.first.name}"
   end
 end

--- a/spec/features/admin/admin_can_deactivate_user_spec.rb
+++ b/spec/features/admin/admin_can_deactivate_user_spec.rb
@@ -17,9 +17,8 @@ feature 'admin deactivates a user' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit question_path(question)
-
-    click_button "Deactivate User"
 byebug
+    click_button "Deactivate User"
     expect(user.roles.count).to eq(1)
     expect(user.roles[0][:name]).to eq('blocked_user')
   end

--- a/spec/features/admin/admin_can_deactivate_user_spec.rb
+++ b/spec/features/admin/admin_can_deactivate_user_spec.rb
@@ -12,6 +12,7 @@ feature 'admin deactivates a user' do
                             password: 'test')
     user.roles.create(name: 'registered_user')
     @question = Fabricate(:question, user: user)
+    Fabricate(:role, name: 'blocked_user')
   end
   scenario 'admin visits question page and deactivates user' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)

--- a/spec/features/admin/admin_can_reactivate_user_spec.rb
+++ b/spec/features/admin/admin_can_reactivate_user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'admin deactivates a user' do
+feature 'admin reactivates a user' do
   attr_reader :admin, :question, :user
 
   before(:each) do
@@ -10,17 +10,17 @@ feature 'admin deactivates a user' do
                             email: 'test',
                             phone: '1',
                             password: 'test')
-    user.roles.create(name: 'registered_user')
+    user.roles.create(name: 'blocked_user')
     @question = Fabricate(:question, user: user)
-    Fabricate(:role, name: 'blocked_user')
+    Fabricate(:role, name: 'registered_user')
   end
-  scenario 'admin visits question page and deactivates user' do
+  scenario 'admin visits question page and reactivates user' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit question_path(question)
 
-    click_button "Deactivate User"
+    click_button "Reactivate User"
     expect(user.roles.count).to eq(1)
-    expect(user.roles[0][:name]).to eq('blocked_user')
+    expect(user.roles[0][:name]).to eq('registered_user')
   end
 end

--- a/spec/features/users/user_is_deactivated_spec.rb
+++ b/spec/features/users/user_is_deactivated_spec.rb
@@ -1,0 +1,181 @@
+require 'rails_helper'
+
+feature 'user is deactivated' do
+  attr_reader :user, :question, :answer
+
+  before(:each) do
+    @user     = User.create(name:'test',
+                            email: 'test',
+                            phone: '1',
+                            password: 'test')
+    user.roles.create(name: 'blocked_user')
+    @question = Fabricate(:question, user: user)
+    @answer   = Fabricate(:answer, question: question)
+  end
+
+  scenario 'deactivated user can view a question' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+    within("#question-title") do
+      expect(page).to have_content(question.title)
+    end
+
+    within("#question-body") do
+      expect(page).to have_content(question.body)
+    end
+    expect(current_path).to eq(question_path(question))
+    within(".question-answers .question-answer:nth-child(1)") do
+      expect(page).to have_content(answer.body)
+    end
+  end
+
+    scenario 'deactivated user can visit root' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      category        = Fabricate(:category)
+
+      visit root_path
+
+      within('.recent-activity') do
+        expect(page).to have_content('Recent Activity')
+        expect(page).to have_content(question.title)
+      end
+
+      within('.categories') do
+        expect(page).to have_content('Categories')
+        expect(page).to have_content(category.name)
+      end
+    end
+
+    scenario 'deactivated user can log in' do
+
+      visit root_path
+
+      click_link 'Login'
+
+      expect(current_path).to eq(login_path)
+
+      fill_in "Name", with: "#{user.name}"
+      fill_in "Password", with: "#{user.password}"
+
+      click_button "Login"
+      expect(current_path).to eq(user_path(user))
+    end
+
+    scenario 'deactivated user can edit their profile' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit user_path(user)
+
+      within("#user-info-table") do
+        click_on "Edit User Profile"
+      end
+
+      expect(current_path).to eq(edit_user_path(user))
+
+      fill_in "Email", with: "no@no.com"
+      fill_in "Phone", with: "123-456-7890"
+
+      click_on("Save")
+
+      expect(current_path).to eq(user_path(user))
+
+      within("#user-info-table") do
+        expect(page).to have_content("no@no.com")
+        expect(page).to have_content("123-456-7890")
+      end
+    end
+
+    scenario 'deactivated user can change their password' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+      token = Fabricate(:password_token, token: '123',  user: user)
+
+      visit user_path(user)
+
+      expect_any_instance_of(PasswordsController).to receive(:send_token)
+      within("#user-info-table") do
+        click_on("Change Password")
+      end
+
+      expect(current_path).to eq(edit_password_path)
+
+      fill_in "Token", with: "123"
+      fill_in "New Password", with: "new_password"
+      fill_in "Password Confirmation", with: "new_password"
+
+      click_on "Save"
+
+      expect(current_path).to eq(user_path(user))
+      expect(user.reload.authenticate("new_password")).to be_truthy
+    end
+
+  scenario 'deactivated user cannot post an answer' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+    fill_in "Enter text", with: "Dumb question"
+    click_button("Submit")
+
+
+    expect(current_path).to eq(root_path)
+    within(".alert-danger") do
+      expect(page).to have_content("Your account priveleges have been limited due to your activity")
+    end
+  end
+
+  scenario 'deactivated user cannot post a comment' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+    within(".question") do
+      fill_in "Add Comment", with: "This is an awesome comment"
+      click_on "Add Comment"
+    end
+
+    expect(current_path).to eq(root_path)
+    within(".alert-danger") do
+      expect(page).to have_content("Your account priveleges have been limited due to your activity")
+    end
+  end
+
+  scenario 'deactivated user cannot delete a question' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+
+    within("#delete-question") do
+      click_on "Delete Question"
+    end
+
+    expect(current_path).to eq(root_path)
+    within(".alert-danger") do
+      expect(page).to have_content("Your account priveleges have been limited due to your activity")
+    end
+
+    expect(Question.count).to eq(1)
+
+    within('.recent-activity') do
+      expect(page).to have_content('Recent Activity')
+      expect(page).to have_content(question.title)
+    end
+  end
+
+    scenario 'deactivated user cannot post a question' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit root_path
+
+      within("#nav-mobile.left") do
+        click_link("Ask Question")
+      end
+
+      expect(current_path).to eq(root_path)
+      within(".alert-danger") do
+        expect(page).to have_content("Your account priveleges have been limited due to your activity")
+      end
+    end
+end


### PR DESCRIPTION
This PR adds the ability for an admin to block as well as unblock a user.  Three methods were added to the user model. 'blocked_user?' returns a boolean if a user has the role of 'blocked_user?'. 'deactivate' deletes all of the users user_roles from the database and creates a user_role with the role being 'blocked_user'.  'reactivate' does the same actions but the user_role generated connects the user to the 'registered_user' role.

'blocked_user_permissions' were added to the permission PORO. Blocked users are not permitted to create/destroy/edit answers, questions, or comments, but they are still able to view all items. They are also permitted to edit their profile and change their password. I refactored a bit and created 'basic_permissions' to pull the standard permissions for the home controller and sessions controller out of all of the permissions and added a reference to basic permissions in all permissions methods.

Feature tests were added to confirm that a user can be deactivated as well as reactivated by admin. Feature tests were added to confirm all deactivated user functionalities worked appropriately and that they weren't able to access un-permitted functionalities.

I modified the seed file to generate a role of 'blocked_user?' by default and shorten up the question titles by default. Locally and in production, we can reseed or we can just generate a role with a name of 'blocked_user' to have this set of features function appropriately.