### PR TITLE
Closes#108 Closes#67

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -14,6 +14,13 @@ class SessionsController < ApplicationController
     end
   end
 
+  def destroy
+    session.clear
+    flash[:success] = "You've logged out.  Come back soon!"
+    redirect_to root_path
+  end
+
+
   private
 
   def session_params

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,8 +10,13 @@
       <% end %>
     </ul>
     <ul id="nav-mobile" class="right">
-      <li><a href="/login" class="black-text">Login</a></li>
-      <li><a href="/users/new" class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
+      <% if current_user.nil? %>
+        <li><a href="/login" class="black-text">Login</a></li>
+        <li><a href="/users/new" class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
+      <% else %>
+        <li><a href="/logout" data-method='delete' class="black-text">Logout</a></li>
+        <li><a href="/users/<%= current_user.id %>" class="waves-effect blue darken-1 waves-light btn">Profile</a></li>
+      <% end %>
     </ul>
   </div>
 </nav>

--- a/spec/features/users/user_logs_in_spec.rb
+++ b/spec/features/users/user_logs_in_spec.rb
@@ -19,6 +19,34 @@ feature 'user visits root' do
 
     click_button "Login"
     expect(current_path).to eq(user_path(user))
+
+    within all('#nav-mobile').last do
+      expect(page).to have_link("Logout")
+      expect(page).to have_link("Profile")
+    end
+  end
+
+  scenario 'logged in user can navigate to profile' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit '/'
+
+    click_link 'Profile'
+
+    expect(current_path).to eq(user_path(user))
+  end
+
+  scenario 'logged in user can log out' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit user_path(user)
+
+    click_link 'Logout'
+
+    expect(current_path).to eq(root_path)
+    within('.alert-success') do
+      expect(page).to have_content("You've logged out.  Come back soon!")
+    end
   end
 
   scenario 'user login fails' do


### PR DESCRIPTION
Modifies navbar with conditional that will
display a create acount button and login
button when there is no current_user.
Same conditional will display a button
to the users profile and a logout button
when there is a current_user. Adds destroy
method to sessions controller. All tests
currently passing. Behavior checked
locally in browser and is as
expected.