### PR TITLE
Dano user delete question comment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_user,
                 :current_permission,
                 :current_admin?,
-                :current_users_question?
+                :current_users_question?,
+                :current_users_comment?
 
   before_action :authorize!
 
@@ -37,6 +38,10 @@ class ApplicationController < ActionController::Base
 
   def current_users_question?(question)
     current_user && current_user.id == question.user_id
+  end
+
+  def current_users_comment?(comment)
+    current_user && current_user.id == comment.user_id
   end
 
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,6 @@
 class CommentsController < ApplicationController
 
   def create
-    binding.pry
     @presenter = Presenter.new
     @question = Question.find(comment_params[:question])
     @answer = Answer.populate_answer(comment_params)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -34,4 +34,12 @@ class Comment < ApplicationRecord
       question.comments.create(body: comment_params[:body])
     end
   end
+
+  def self.check_comments
+    if count >= 1 && first.body != nil
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -38,7 +38,7 @@ private
     return true if controller == "users" && action.in?(%w(show edit update))
     return true if controller == "questions" && action.in?(%w(index show new create destroy edit update))
     return true if controller == "answers" && action.in?(%w(create destroy))
-    return true if controller == "comments" && action.in?(%w(create))
+    return true if controller == "comments" && action.in?(%w(create destroy))
     return true if controller == "passwords" && action.in?(%w(edit update))
     basic_permissions
   end

--- a/app/views/comments/_questioncomments.html.erb
+++ b/app/views/comments/_questioncomments.html.erb
@@ -5,7 +5,7 @@
         <div id="question-comment-body" class="card-action" style= padding-left:50px;>
           <p><%= comment.body %></p>
           <div id='delete-comment-button' class='left card-action'>
-            <% if current_admin? %>
+            <% if current_admin? || current_users_comment?(comment)%>
               <%= button_to "Delete Comment", comment_path(comment), method: :delete, class: "waves-effect red darken-4 waves-light btn-small" %>
             <% end %>
           </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -38,7 +38,6 @@
       </div>
         <br><br><br>
         <div class="divider"></div>
-        <% #if !@question.comments.empty? %>
         <% if @question.comments.check_comments %>
           <%= render 'comments/questioncomments' %>
         <% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -38,7 +38,8 @@
       </div>
         <br><br><br>
         <div class="divider"></div>
-        <% if !@question.comments.empty? %>
+        <% #if !@question.comments.empty? %>
+        <% if @question.comments.check_comments %>
           <%= render 'comments/questioncomments' %>
         <% end %>
         <%= form_for [@question, @comment], url: { controller: "comments", action: "create" } do |f| %>

--- a/spec/features/users/user_can_delete_their_own_comments_spec.rb
+++ b/spec/features/users/user_can_delete_their_own_comments_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe 'when a user visits a question show page' do
+  it 'they can delete question comments owned by them' do
+    user = Fabricate(:user, id: 1)
+    question = Fabricate(:question, user: user)
+    comment = question.comments.create!(body: "Nice comment", user_id: user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit question_path(question)
+
+    expect(page).to have_content(comment.body)
+
+    within('#question-comments') do
+      click_on 'Delete Comment'
+    end
+
+    expect(page).to_not have_content("Nice comment")
+  end
+
+  it 'non owner cannot delete comment' do
+    user1 = Fabricate(:user, id: 1)
+    user2 = Fabricate(:user, id: 2)
+    question = Fabricate(:question, user: user1)
+    comment = question.comments.create!(body: "Nice comment", user_id: user1.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user2)
+
+    visit question_path(question)
+
+    within('#question-comments') do
+      expect(page).to_not have_button("Delete Comment")
+    end
+  end
+end


### PR DESCRIPTION
Add delete comment functionality to questions. Permissions in place to only allow owner of comment and admin to have delete capability. @andrewdwooten and I had to refactor the conditional for rendering question answers partial. Works like a charm now.