### PR TITLE
Fix comment bug

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,7 +10,7 @@ class CommentsController < ApplicationController
     @upvote = Upvote.new
     if @comment.save
       flash[:success] = "Comment successfully created"
-      redirect_to request.referer
+      redirect_to question_path(@question)
     else
       flash[:danger] = "Comment failed. Please re-enter your comment."
       render 'questions/show'


### PR DESCRIPTION
Using redirect_to request.referer was causing trouble here. When a comment failed, the url was still /comments. When we posted a successful comment, it was trying to redirect to the referer, in this case, /comments. Changing to this to a regular old redirect seems to do the trick.