### PR TITLE
Complete admin blocking priveleges

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,9 @@ class ApplicationController < ActionController::Base
                 :current_admin?,
                 :current_users_question?,
                 :current_users_comment?,
-                :current_users_answer?
+                :current_users_answer?,
+                :display_block_button?,
+                :display_unblock_button?
 
   before_action :authorize!
 
@@ -47,5 +49,15 @@ class ApplicationController < ActionController::Base
 
   def current_users_answer?(answer)
     current_user && current_user.id == answer.user_id
+  end
+
+  def display_block_button?(question)
+    current_admin? && !question.user.blocked_user? &&
+     !current_users_question?(@question)
+  end
+
+  def display_unblock_button?(question)
+    current_admin? && question.user.blocked_user? &&
+     !current_users_question?(@question)
   end
 end

--- a/app/controllers/user_permissions_controller.rb
+++ b/app/controllers/user_permissions_controller.rb
@@ -2,7 +2,7 @@ class UserPermissionsController < ApplicationController
 
   def update
     user = User.find(params[:id])
-    if user.registered_user?
+    if !user.blocked_user?
       user.deactivate
     else
       user.reactivate

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,9 +1,9 @@
 <h2>Question</h2>
-<% if current_admin? && @question.user.registered_user? %>
+<% if display_block_button?(@question) %>
   <div id='deactivate-user-button' class='right card-action'>
     <%= button_to "Deactivate User", user_permission_path(@question.user), method: :put, class: "waves-effect red darken-1 waves-light btn right" %>
   </div>
-<% elsif current_admin? && @question.user.blocked_user? %>
+<% elsif display_unblock_button?(@question) %>
   <div id='reactivate-user-button' class='right card-action'>
     <%= button_to "Reactivate User", user_permission_path(@question.user), method: :put, class: "waves-effect red darken-1 waves-light btn right" %>
   </div>

--- a/spec/features/admin/admin_can_deactivate_user_spec.rb
+++ b/spec/features/admin/admin_can_deactivate_user_spec.rb
@@ -23,4 +23,46 @@ feature 'admin deactivates a user' do
     expect(user.roles.count).to eq(1)
     expect(user.roles[0][:name]).to eq('blocked_user')
   end
+
+  scenario 'admin can deactivate another admin' do
+    user.roles.create(name: 'admin')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    question2 = Fabricate(:question, user: admin)
+
+    visit question_path(question)
+
+    click_button "Deactivate User"
+    expect(user.roles.count).to eq(1)
+    expect(user.roles[0][:name]).to eq('blocked_user')
+  end
+
+  scenario 'admin can reactivate a blocked user' do
+    user.roles.create(name: 'blocked_user')
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    question2 = Fabricate(:question, user: admin)
+
+    visit question_path(question)
+
+    click_button "Reactivate User"
+    expect(user.roles.count).to eq(1)
+    expect(user.roles[0][:name]).to eq('registered_user')
+  end
+
+  scenario 'admin cannot deactivate self' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    question2 = Fabricate(:question, user: admin)
+
+    visit question_path(question2)
+
+    expect(page).to_not have_css('#deactivate-user-button')
+  end
+
+  scenario 'user cannot find deactivate user button' do
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    question2 = Fabricate(:question, user: admin)
+
+    visit question_path(question2)
+
+    expect(page).to_not have_css('#deactivate-user-button')
+  end
 end


### PR DESCRIPTION
Grants admin the ability to ban other users with
an admin role. Removes ability for an admin to
ban self. Adds display_block_button? and
display_unblock_button? method to application
controller; it was a significant amount of logic
cluttering up the view, so I chose to force it down 
the stack. Modifies UserPermissions controller
update method such that an admin can be banned.
Testing added to confirm new scenarios.
All tests currently passing with coverage rate of
98.83%. Running application locally shows new
banning logic to be functioning as expected.