### PR TITLE
Allow user to only edit their own profile

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :authorize!
 
   def current_user
-    @user ||= User.find(session[:user_id]) if session[:user_id]
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
   def current_permission

--- a/app/views/users/_user_info.html.erb
+++ b/app/views/users/_user_info.html.erb
@@ -15,32 +15,36 @@
                 E-Mail:
               </td>
               <td>
-                <%= current_user.email %>
+                <%= @user.email %>
               </td>
             </tr>
             <tr>
-              <td>
-                Phone:
-              </td>
-              <td>
-                <%= current_user.phone %>
-              </td>
+              <% if current_user == @user %>
+                <td>
+                  Phone:
+                </td>
+                <td>
+                  <%= @user.phone %>
+                </td>
+              <% end %>
             </tr>
             <tr>
               <td>
                 Reputation:
               </td>
               <td id='user-street-rep'>
-                <%= current_user.reputation %>
+                <%= @user.reputation %>
               </td>
             </tr>
             <tr>
-              <td>
-                <%= link_to "Edit User Profile", edit_user_path(current_user), style: "color: white" %>
-              </td>
-              <td>
-                <%= link_to "Change Password", edit_password_path, style: "color: white" %>
-              </td>
+              <% if current_user == @user %>
+                <td>
+                  <%= link_to "Edit User Profile", edit_user_path(current_user), style: "color: white" %>
+                </td>
+                <td>
+                  <%= link_to "Change Password", edit_password_path, style: "color: white" %>
+                </td>
+              <% end %>
             </tr>
           </tbody>
         </table>
@@ -54,7 +58,7 @@
       <%= gravatar_image_tag @user.email, alt: @user.name, gravatar: { size: 200, default: "http://www.ulyces.co/wp-content/plugins/tia-author-image/default_user_icon.jpg" }, class: "user-pic" %>
       <hr>
         <div class="user-name" >
-          Name: <%= current_user.name %>
+          Name: <%= @user.name %>
         </div>
       </div>
     </div>

--- a/spec/features/admin/admin_dashboard_spec.rb
+++ b/spec/features/admin/admin_dashboard_spec.rb
@@ -6,6 +6,7 @@ feature 'admin show page' do
               :thing3,
               :good,
               :admin
+
   before(:each) do
     @thing1 = Fabricate(:user, reputation: -50, name: 'thing1')
     thing1.user_roles.delete_all
@@ -17,15 +18,17 @@ feature 'admin show page' do
       thing3.roles.create(name: 'blocked_user')
     @good   = Fabricate(:user, reputation: 200)
       good.roles.create(name: 'registered_user')
-    @admin = Fabricate(:user)
+    @admin = Fabricate(:user, name: "BigBob")
+      admin.user_roles.delete_all
       admin.roles.create(name: 'admin')
   end
+
   scenario 'admin has users to deactivate listed on the show page' do
     login(admin.name)
     visit user_path(admin)
 
     expect(page).to have_css('#users-to-deactivate')
- 
+
     within('#users-to-deactivate') do
       expect(page).to have_content('thing1')
       expect(page).to have_content('thing2')

--- a/spec/features/users/user_views_profiles_spec.rb
+++ b/spec/features/users/user_views_profiles_spec.rb
@@ -4,9 +4,9 @@ feature 'user profile' do
   attr_reader :user
   before(:each) do
     @user = Fabricate(:user)
-    @user.roles.create(name: 'registered_user')
   end
-  scenario 'user sees their account information' do
+
+  scenario 'user sees their own account information' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit user_path(user)
@@ -64,12 +64,13 @@ feature 'user profile' do
     question4 = Fabricate(:question)
     question5 = Fabricate(:question)
     question6 = Fabricate(:question)
-    answer1 = Fabricate(:answer, user: user, question: question1)
-    answer2 = Fabricate(:answer, user: user, question: question2)
-    answer3 = Fabricate(:answer, user: user, question: question3)
-    answer4 = Fabricate(:answer, user: user, question: question4)
-    answer5 = Fabricate(:answer, user: user, question: question5)
-    answer6 = Fabricate(:answer, user: user, question: question6)
+
+    Fabricate(:answer, user: user, question: question1)
+    Fabricate(:answer, user: user, question: question2)
+    Fabricate(:answer, user: user, question: question3)
+    Fabricate(:answer, user: user, question: question4)
+    Fabricate(:answer, user: user, question: question5)
+    Fabricate(:answer, user: user, question: question6)
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -87,6 +88,7 @@ feature 'user profile' do
       expect(page).to have_link(question2.title, href: question_path(question2))
     end
   end
+
   scenario 'user sees the 5 most recent comments left on their work' do
     user2 = Fabricate(:user)
     question1 = Fabricate(:question, title: 'test', user: user)
@@ -110,5 +112,24 @@ feature 'user profile' do
       expect(page).to have_link(question1.title, href: question_path(question1))
       expect(page).to have_link(question1.title, href: question_path(question1))
     end
+  end
+
+  scenario "user visits another user's profile" do
+    user = Fabricate(:user)
+    user_2 = Fabricate(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user)
+      .and_return(user)
+
+    visit user_path(user_2)
+
+    within('#user-info-table') do
+      expect(page).to have_content(user.email)
+      expect(page).to_not have_content(user.phone)
+      expect(page).to have_content('Reputation')
+      expect(page).to_not have_link("Edit Profile")
+    end
+
+
   end
 end


### PR DESCRIPTION
This ensures a user only sees the Edit Profile button on their own profile. They can visit another person's profile, but can't view their phone number. I ran into some bugs in our code, but I think I found them all and now all tests are passing.