### PR TITLE
Banned users endpoint

### DIFF
--- a/app/controllers/api/v1/users/users_banned_controller.rb
+++ b/app/controllers/api/v1/users/users_banned_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Users::UsersBannedController < ApplicationController
+
+  def index
+    render json: User.banned, each_serializer: UserBannedSerializer
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,15 +65,13 @@ class User < ApplicationRecord
   def self.by_reputation
     order(:reputation).reverse_order[0..9]
   end
-  
+
   def self.need_to_block
     joins(:roles).where("roles.name != 'blocked_user'")
     .where("users.reputation <= -10")
   end
 
   def self.banned
-    # joins(:roles)
-    # .where("roles.name = 'blocked_user'")
     find_by_sql([
       "select u.id, u.name, u.email, u.reputation, r.name AS status
       from users u

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,4 +70,16 @@ class User < ApplicationRecord
     joins(:roles).where("roles.name != 'blocked_user'")
     .where("users.reputation <= -10")
   end
+
+  def self.banned
+    # joins(:roles)
+    # .where("roles.name = 'blocked_user'")
+    find_by_sql([
+      "select u.id, u.name, u.email, u.reputation, r.name AS status
+      from users u
+      inner join user_roles ur on u.id = ur.user_id
+      inner join roles r on ur.role_id = r.id
+      where r.name = 'blocked_user';"
+      ])
+  end
 end

--- a/app/serializers/user_banned_serializer.rb
+++ b/app/serializers/user_banned_serializer.rb
@@ -1,0 +1,3 @@
+class UserBannedSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email, :reputation, :status
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :phone, :reputation
+  attributes :id, :name, :email, :reputation
 end

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -64,5 +64,6 @@ private
     return true if controller == "home"
     return true if controller == "api/v1/users" && action.in?(%w(show))
     return true if controller == "api/v1/users/users_by_reputation" && action.in?(%w(index))
+    return true if controller == "api/v1/users/users_banned" && action.in?(%w(index))
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :users do
         get "/by_reputation", to: "users_by_reputation#index"
+        get "/banned", to: "users_banned#index"
       end
 
       resources :users, only: [:show, :index] do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,8 @@ ActiveRecord::Schema.define(version: 20170404012145) do
     t.text     "body"
     t.integer  "question_id"
     t.integer  "user_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["question_id"], name: "index_answers_on_question_id", using: :btree
     t.index ["user_id"], name: "index_answers_on_user_id", using: :btree
   end
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 20170404012145) do
     t.text     "body"
     t.integer  "user_id"
     t.integer  "category_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "best_answer_id"
     t.index ["category_id"], name: "index_questions_on_category_id", using: :btree
     t.index ["user_id"], name: "index_questions_on_user_id", using: :btree

--- a/spec/requests/api/v1/users/user_request_spec.rb
+++ b/spec/requests/api/v1/users/user_request_spec.rb
@@ -12,12 +12,10 @@ describe "user API" do
 
     expect(user).to have_key "name"
     expect(user).to have_key "email"
-    expect(user).to have_key "phone"
     expect(user).to have_key "reputation"
 
     expect(user["name"]).to eq("Jabrony")
     expect(user["email"]).to eq("Jabron@jabron.com")
-    expect(user["phone"]).to eq("333-333-3333")
     expect(user["reputation"]).to eq(3)
     expect(user["reputation"]).to_not eq(2)
   end

--- a/spec/requests/api/v1/users/users_banned_spec.rb
+++ b/spec/requests/api/v1/users/users_banned_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+describe "banned_users API" do
+  it "sends banned users" do
+    user_1 = User.create(name: "Tom Riddle", email: 'lord@voldemort.com', phone: '1', password: 'riddle', reputation: -1000)
+    user_2 = User.create(name: "Draco Malfoy", email: 'draco@malfoy.com', phone: '2', password: 'malfoy', reputation: -20)
+    user_3 = User.create(name: "Bellatrix", email: 'bella@trix.com', phone: '2', password: 'bella', reputation: -100)
+    user_4 = User.create(name: "Dolores Umbridge", email: 'dolores@umbridge.com', phone: '2', password: 'pureblood', reputation: -50)
+    user_5 = User.create(name: "Scorpious Malfoy", email: 'scorpio@malfoy.com', phone: '2', password: 'malfoy', reputation: -10)
+
+    user_1.roles.create(name: 'blocked_user')
+    user_2.roles.create(name: 'blocked_user')
+    user_3.roles.create(name: 'blocked_user')
+    user_4.roles.create(name: 'blocked_user')
+    user_5.roles.create(name: 'blocked_user')
+
+    get '/api/v1/users/banned'
+
+    expect(response).to be_success
+
+    users       = JSON.parse(response.body)
+    user        = users.first
+    second_user = users.second
+    last_user   = users.last
+
+    expect(users.count).to eq(5)
+
+    expect(user).to have_key "name"
+    expect(user).to have_key "email"
+    expect(user).to have_key "reputation"
+    expect(user).to have_key "status"
+
+    expect(user["name"]).to eq("Tom Riddle")
+    expect(user["email"]).to eq("lord@voldemort.com")
+    expect(user["reputation"]).to eq(-1000)
+    expect(user["status"]).to eq("blocked_user")
+
+
+    expect(second_user["name"]).to eq("Draco Malfoy")
+    expect(second_user["email"]).to eq("draco@malfoy.com")
+    expect(second_user["reputation"]).to eq(-20)
+    expect(second_user["reputation"]).to_not eq(8)
+    expect(user["status"]).to eq("blocked_user")
+
+    expect(last_user["name"]).to eq("Scorpious Malfoy")
+    expect(last_user["email"]).to eq("scorpio@malfoy.com")
+    expect(last_user["reputation"]).to eq(-10)
+    expect(last_user["reputation"]).to_not eq(3)
+    expect(user["status"]).to eq("blocked_user")
+  end
+end

--- a/spec/requests/api/v1/users/users_banned_spec.rb
+++ b/spec/requests/api/v1/users/users_banned_spec.rb
@@ -7,12 +7,14 @@ describe "banned_users API" do
     user_3 = User.create(name: "Bellatrix", email: 'bella@trix.com', phone: '2', password: 'bella', reputation: -100)
     user_4 = User.create(name: "Dolores Umbridge", email: 'dolores@umbridge.com', phone: '2', password: 'pureblood', reputation: -50)
     user_5 = User.create(name: "Scorpious Malfoy", email: 'scorpio@malfoy.com', phone: '2', password: 'malfoy', reputation: -10)
+    user_6 = User.create(name: "Harry Potter", email: 'harry@thechosenone.com', phone: '7', password: 'chosen', reputation: 1000)
 
     user_1.roles.create(name: 'blocked_user')
     user_2.roles.create(name: 'blocked_user')
     user_3.roles.create(name: 'blocked_user')
     user_4.roles.create(name: 'blocked_user')
     user_5.roles.create(name: 'blocked_user')
+    user_6.roles.create(name: 'registered_user')
 
     get '/api/v1/users/banned'
 
@@ -24,6 +26,7 @@ describe "banned_users API" do
     last_user   = users.last
 
     expect(users.count).to eq(5)
+    expect(users.count).to_not eq(6)
 
     expect(user).to have_key "name"
     expect(user).to have_key "email"
@@ -47,5 +50,7 @@ describe "banned_users API" do
     expect(last_user["reputation"]).to eq(-10)
     expect(last_user["reputation"]).to_not eq(3)
     expect(user["status"]).to eq("blocked_user")
+
+    expect(last_user["name"]).to_not eq("Harry Potter")
   end
 end

--- a/spec/requests/api/v1/users/users_by_reputation_spec.rb
+++ b/spec/requests/api/v1/users/users_by_reputation_spec.rb
@@ -23,24 +23,20 @@ describe "by_reputation API" do
 
     expect(user).to have_key "name"
     expect(user).to have_key "email"
-    expect(user).to have_key "phone"
     expect(user).to have_key "reputation"
 
     expect(user["name"]).to eq("Jabrony")
     expect(user["email"]).to eq("Jabron@jabron.com")
-    expect(user["phone"]).to eq("333-333-3333")
     expect(user["reputation"]).to eq(10)
     expect(user["reputation"]).to_not eq(2)
 
     expect(second_user["name"]).to eq("Jimjam")
     expect(second_user["email"]).to eq("Jimjam@jabron.com")
-    expect(second_user["phone"]).to eq("444-444-4444")
     expect(second_user["reputation"]).to eq(9)
     expect(second_user["reputation"]).to_not eq(8)
 
     expect(last_user["name"]).to eq("Gobledigook")
     expect(last_user["email"]).to eq("Hambone@alabaster.io")
-    expect(last_user["phone"]).to eq("111-111-1111")
     expect(last_user["reputation"]).to eq(1)
     expect(last_user["reputation"]).to_not eq(3)
   end


### PR DESCRIPTION
Builds Banned User Endpoint for API:
Creates banned user route, name spaced controller, custom serializer,
and tests for returning banned users.

Custom serializer uses each_serializer, which enables returns of 
information from multiple tables, and a query that includes the user role 
name (ie - 'banned_user') as 'status.'

Adjusts user serializer to exclude phone from the endpoint.
Also makes the banned user test more robust with
ensuring that non-banned users are not returned.

Tests written with infamous Slytherins. 
![image](https://cloud.githubusercontent.com/assets/19553401/24684115/e4c4a1c0-1960-11e7-8425-892507d564d3.png)
