### PR TITLE
Adds Mailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Ignore application configuration
 /config/application.yml
+/config/secrets.yml

--- a/app/controllers/user_permissions_controller.rb
+++ b/app/controllers/user_permissions_controller.rb
@@ -4,8 +4,10 @@ class UserPermissionsController < ApplicationController
     user = User.find(params[:id])
     if !user.blocked_user?
       user.deactivate
+      UserMailer.blocked_email(user).deliver_now
     else
       user.reactivate
+      UserMailer.unblocked_email(user).deliver_now
     end
     redirect_to request.referrer
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      UserMailer.welcome_email(@user).deliver_now
       UserRole.create(user_id:@user.id, role_id:1)
       session[:user_id] = @user.id
       redirect_to user_path(@user)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: "cloneyislandmailer@gmail.com"
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,13 @@
+class UserMailer < ApplicationMailer
+default from: "cloneyislandmailer@gmail.com"
+
+  def welcome_email(user)
+    @user = user
+    mail(to: @user.email, subject: 'Welcome to Stack')
+  end
+
+  def blocked_email(user)
+    @user = user
+    mail(to: @user.email, subject: "Ban Notice")
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,6 +8,11 @@ default from: "cloneyislandmailer@gmail.com"
 
   def blocked_email(user)
     @user = user
-    mail(to: @user.email, subject: "Ban Notice")
+    mail(to: @user.email, subject: 'Ban Notice')
+  end
+
+  def unblocked_email(user)
+    @user = user
+    mail(to: @user.email, subject: 'Welcome Back')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,11 +61,10 @@ class User < ApplicationRecord
     answers.joins(:best_question).count
   end
 
-
   def self.by_reputation
     order(:reputation).reverse_order[0..9]
   end
-  
+
   def self.need_to_block
     joins(:roles).where("roles.name != 'blocked_user'")
     .where("users.reputation <= -10")

--- a/app/views/user_mailer/blocked_email.html.erb
+++ b/app/views/user_mailer/blocked_email.html.erb
@@ -6,9 +6,9 @@
   <body>
     <h1>Hi <%= @user.name %>,</h1>
       <p>
-        Your user priveleges have been restricted due to your
+        Your user privileges have been restricted due to your
         reputation of <%= @user.reputation %>. You won't be able
-        to alter any content on the site until your priveleges
+        to alter any content on the site until your privileges
         are reinstated. You are still welcome to browse questions
         and answers to satisfy your thirst for knowledge. Take care.
       </p>

--- a/app/views/user_mailer/blocked_email.html.erb
+++ b/app/views/user_mailer/blocked_email.html.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hi <%= @user.name %>,</h1>
+      <p>
+        Your user priveleges have been restricted due to your
+        reputation of <%= @user.reputation %>. You won't be able
+        to alter any content on the site until your priveleges
+        are reinstated. You are still welcome to browse questions
+        and answers to satisfy your thirst for knowledge. Take care.
+      </p>
+      <p>
+        Thanks,
+      </p>
+      <p>
+        The Cloney Island Stack Team</br>
+        <a href=https://pure-wildwood-52964.herokuapp.com/>Come hang out!</a>
+      </p>
+  </body>
+</html>

--- a/app/views/user_mailer/blocked_email.text.erb
+++ b/app/views/user_mailer/blocked_email.text.erb
@@ -1,8 +1,8 @@
 Hi <%= @user.name %>,
 
-  Your user priveleges have been restricted due to your
+  Your user privileges have been restricted due to your
   reputation of <%= @user.reputation %>. You won't be able
-  to alter any content on the site until your priveleges
+  to alter any content on the site until your privileges
   are reinstated. You are still welcome to browse questions
   and answers to satisfy your thirst for knowledge. Take care.
 

--- a/app/views/user_mailer/blocked_email.text.erb
+++ b/app/views/user_mailer/blocked_email.text.erb
@@ -1,0 +1,10 @@
+Hi <%= @user.name %>,
+
+  Your user priveleges have been restricted due to your
+  reputation of <%= @user.reputation %>. You won't be able
+  to alter any content on the site until your priveleges
+  are reinstated. You are still welcome to browse questions
+  and answers to satisfy your thirst for knowledge. Take care.
+  
+Thanks,
+The Cloney Island Stack Team

--- a/app/views/user_mailer/blocked_email.text.erb
+++ b/app/views/user_mailer/blocked_email.text.erb
@@ -5,6 +5,7 @@ Hi <%= @user.name %>,
   to alter any content on the site until your priveleges
   are reinstated. You are still welcome to browse questions
   and answers to satisfy your thirst for knowledge. Take care.
-  
+
 Thanks,
 The Cloney Island Stack Team
+https://pure-wildwood-52964.herokuapp.com

--- a/app/views/user_mailer/unblocked_email.html.erb
+++ b/app/views/user_mailer/unblocked_email.html.erb
@@ -7,9 +7,9 @@
     <h1>Hi <%= @user.name %>,</h1>
       <p>
         Welcome back! Thanks to the remarkable turnaround we've seen
-        in your behavior, we've happily re-instated your posting
-        priveleges. We're glad to have you back. As always, we're here
-        to help in any way we can in your quest for knowlede.
+        in your behavior, we've happily reinstated your posting
+        privileges. We're glad to have you back. As always, we're here
+        to help in any way we can in your quest for knowledge.
       </p>
       <p>
         Thanks,

--- a/app/views/user_mailer/unblocked_email.html.erb
+++ b/app/views/user_mailer/unblocked_email.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hi <%= @user.name %>,</h1>
+      <p>
+        Welcome back! Thanks to the remarkable turnaround we've seen
+        in your behavior, we've happily re-instated your posting
+        priveleges. We're glad to have you back. As always, we're here
+        to help in any way we can in your quest for knowlede.
+      </p>
+      <p>
+        Thanks,
+      </p>
+      <p>
+        The Cloney Island Stack Team</br>
+        <a href=https://pure-wildwood-52964.herokuapp.com/>Come hang out!</a>
+      </p>
+  </body>
+</html>

--- a/app/views/user_mailer/unblocked_email.text.erb
+++ b/app/views/user_mailer/unblocked_email.text.erb
@@ -1,0 +1,10 @@
+Hi <%= @user.name %>,
+
+    Welcome back! Thanks to the remarkable turnaround we've seen
+    in your behavior, we've happily re-instated your posting
+    priveleges. We're glad to have you back. As always, we're here
+    to help in any way we can in your quest for knowlede.
+
+Thanks,
+
+The Cloney Island Stack Team

--- a/app/views/user_mailer/unblocked_email.text.erb
+++ b/app/views/user_mailer/unblocked_email.text.erb
@@ -1,9 +1,9 @@
 Hi <%= @user.name %>,
 
     Welcome back! Thanks to the remarkable turnaround we've seen
-    in your behavior, we've happily re-instated your posting
-    priveleges. We're glad to have you back. As always, we're here
-    to help in any way we can in your quest for knowlede.
+    in your behavior, we've happily reinstated your posting
+    privileges. We're glad to have you back. As always, we're here
+    to help in any way we can in your quest for knowledge.
 
 Thanks,
 

--- a/app/views/user_mailer/welcome_email.html..erb
+++ b/app/views/user_mailer/welcome_email.html..erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hi <%= @user.name %></h1>,
+    <p>
+      Thanks for joining our clone of StackOverflow! We're excited to have you.
+      Please visit us and post some questions!
+
+      Thanks,
+      The Cloney Island Stack Team
+      <a href=https://pure-wildwood-52964.herokuapp.com/>Come hang out!</a>
+    </p>
+  </body>
+</html>

--- a/app/views/user_mailer/welcome_email.text.erb
+++ b/app/views/user_mailer/welcome_email.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @user.name %>,
+
+Thanks for joining our clone of StackOverflow! We're excited to have you.
+Please visit us and post some questions!
+
+Thanks,
+The Cloney Island Stack Team
+https://pure-wildwood-52964.herokuapp.com

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,12 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.action_mailer.smtp_settings = {
+   :address              => "smtp.gmail.com",
+   :port                 => 587,
+   :user_name            => Rails.application.secrets[:email],
+   :password             => Rails.application.secrets[:password],
+   :authentication       => "plain",
+  :enable_starttls_auto => true
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+
+  config.action_mailer.delivery_method = :smtp
+  # SMTP settings for gmail
+  config.action_mailer.smtp_settings = {
+   :address              => "smtp.gmail.com",
+   :port                 => 587,
+   :user_name            => ENV['EMAIL'],
+   :password             => ENV['PASSWORD'],
+   :authentication       => "plain",
+  :enable_starttls_auto => true
+  }
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,7 +12,8 @@
 
 development:
   secret_key_base: 79b6fed857102a03cf6815ba94a75a1984cb4b14c9a9b72a472ca53596f5b96bae4472cfd74f270e09288dcde1ca96b937d37c97beefc596fa9f3878be2ffbf0
-
+  email: cloneyislandmailer@gmail.com
+  password: PassWord1234!
 test:
   secret_key_base: 0b0c57f39bb9a57bd194422bafa3c99564c4ed48c5136219bd737b5288a69c6cef8a685d7d632f221606e5763ed6c4cfde62b4ed2647e911de0bcae9a2053dae
 
@@ -20,3 +21,5 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  email: <%= ENV['EMAIL']%>
+  password:  <%= ENV['PASSWORD'] %>

--- a/spec/models/user_mailer_spec.rb
+++ b/spec/models/user_mailer_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe UserMailer, type: :mailer do
+  describe '#welcome_email' do
+    let(:user) { Fabricate(:user, name: 'test',
+                                  email: 'test@email.com',
+                                  phone: '123-456-789',
+                                  password: 'password')}
+    let(:mail) { described_class.welcome_email(user).deliver_now }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('Welcome to Stack')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eq(["cloneyislandmailer@gmail.com"])
+    end
+
+    it 'has the link to the site in the body' do
+      expect(mail.body.raw_source.include?('https://pure-wildwood-52964.herokuapp.com')).to eq (true)
+    end
+  end
+  describe '#blocked_email' do
+    let(:user) { Fabricate(:user, name: 'test',
+                                  email: 'test@email.com',
+                                  phone: '123-456-789',
+                                  password: 'password')}
+    let(:mail) { UserMailer.blocked_email(user).deliver_now }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('Ban Notice')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eq(["cloneyislandmailer@gmail.com"])
+    end
+  end
+  describe '#unblocked_email' do
+    let(:user) { Fabricate(:user, name: 'test',
+                                  email: 'test@email.com',
+                                  phone: '123-456-789',
+                                  password: 'password')}
+    let(:mail) { described_class.unblocked_email(user).deliver_now }
+
+    it 'renders the subject' do
+      expect(mail.subject).to eq('Welcome Back')
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eq(["cloneyislandmailer@gmail.com"])
+    end
+  end
+end


### PR DESCRIPTION
Adds UserMailer to application. Same has methods built
to send a welcome e-mail as well as an e-mail when a user
is deactivated. Welcome e-mail is triggered when a user
is created. The blocked e-mail is triggered when the user
is deactivated; the unblocked e-mail is triggered when the
user is re-activated.
Development tests have shown the feature to be
functioning as intended. All local tests currently
passing.
Adds model testing for the UserMailer.
Assertions made query the subject line,
sender, and receiver. Am unable to find
a way to query the body of the message
at this time. Testing coverage is showing
to be 100% for the UserMailer. All previous
testing is currently passing; overall test coverage
is at 98.89% per SimpleCov.
Adding the email and email password to the application.yml
for figaro to use in production is probably a good idea to save
having to manually assign variables in the production environment.
Closes #151