### PR TITLE
Fix lingering flash methods

### DIFF
--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -12,7 +12,7 @@ class AnswersController < ApplicationController
       flash[:success] = "You answered the question!"
       redirect_to question_path(@question)
     else
-      flash[:danger] = "Your comment was not successful."
+      flash.now[:danger] = "Your comment was not successful."
       render "questions/show"
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -12,7 +12,7 @@ class CommentsController < ApplicationController
       flash[:success] = "Comment successfully created"
       redirect_to question_path(@question)
     else
-      flash[:danger] = "Comment failed. Please re-enter your comment."
+      flash.now[:danger] = "Comment failed. Please re-enter your comment."
       render 'questions/show'
     end
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -21,7 +21,7 @@ class QuestionsController < ApplicationController
       redirect_to question_path(@question)
     else
       @categories = Category.all
-      flash[:danger] = "Failed to create question"
+      flash.now[:danger] = "Failed to create question"
       render :new
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
       session[:user_id] = user.id
       redirect_to user_path(user)
     else
-      flash[:danger] = 'Invalid Credentials'
+      flash.now[:danger] = 'Invalid Credentials'
       render :new
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
       session[:user_id] = @user.id
       redirect_to user_path(@user)
     else
+      flash.now[:danger] = "Account creation unsuccessful"
       render :new
     end
   end
@@ -27,6 +28,7 @@ class UsersController < ApplicationController
     if current_user.update_attributes(user_update_params)
       redirect_to user_path(current_user)
     else
+      flash.now[:danger] = "Account update unsuccessful"
       render :edit
     end
   end


### PR DESCRIPTION
Changes flash message to include .now when they are coupled with a render. Using the regular flash message made them stick around one request too long.