### PR TITLE
Modify navbar

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,7 @@
 <nav>
   <div class="nav-wrapper">
-    <ul id="nav-mobile" class="left">
+    <a href="#" data-activates="mobile-demo" class="button-collapse blue"><i class="material-icons">menu</i></a>
+    <ul id="nav-mobile" class="left hide-on-med-and-down">
       <li><a href=<%= root_path  %>><%= image_tag("stack_logo.png", height: "45", width: "135") %></a></li>
       <li><a href=<%= questions_path %> class="black-text">Questions</a></li>
       <% if params[:category].nil? %>
@@ -9,7 +10,26 @@
         <li><a href=<%= new_question_path(:category => params[:category]) %> class="black-text">Ask Question</a></li> %>
       <% end %>
     </ul>
-    <ul id="nav-mobile" class="right">
+    <ul id="mobile-demo" class="side-nav">
+      <li><a href=<%= root_path  %>><%= image_tag("stack_logo.png", height: "45", width: "135") %></a></li>
+      <li><a href=<%= questions_path %> class="black-text">Questions</a></li>
+      <% if params[:category].nil? %>
+        <li> <a href=<%= new_question_path %> class="black-text">Ask Question</a></li>
+      <% else %>
+        <li><a href=<%= new_question_path(:category => params[:category]) %> class="black-text">Ask Question</a></li> %>
+      <% end %>
+    </ul>
+    <a href="#" data-activates="mobile-demo2" class="button-collapse blue right"><i class="material-icons">menu</i></a>
+    <ul id="nav-mobile2" class="right hide-on-med-and-down">
+        <% if current_user.nil? %>
+        <li><a href="/users/new" class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
+        <li><a href="/login" class="black-text">Login</a></li>
+      <% else %>
+        <li><a href="/users/<%= current_user.id %>" class="waves-effect blue darken-1 waves-light btn">Profile</a></li>
+        <li><a href="/logout" data-method='delete' class="black-text">Logout</a></li>
+      <% end %>
+    </ul>
+    <ul id="mobile-demo2" class="side-nav">
       <% if current_user.nil? %>
         <li><a href="/users/new" class="waves-effect blue darken-1 waves-light btn">Sign Up</a></li>
         <li><a href="/login" class="black-text">Login</a></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
     <script>
      $(document).ready(function() {
         $('select').material_select();
+        $(".button-collapse").sideNav();
     });
   </script>
   </body>

--- a/spec/features/users/user_is_deactivated_spec.rb
+++ b/spec/features/users/user_is_deactivated_spec.rb
@@ -52,7 +52,9 @@ feature 'user is deactivated' do
 
       visit root_path
 
-      click_link 'Login'
+      within('#nav-mobile2') do
+        click_link 'Login'
+      end
 
       expect(current_path).to eq(login_path)
 

--- a/spec/features/users/user_logs_in_spec.rb
+++ b/spec/features/users/user_logs_in_spec.rb
@@ -12,7 +12,9 @@ feature 'user visits root' do
 
     expect(page).to have_css('#welcome_jumbotron')
 
-    click_link 'Login'
+    within('#nav-mobile2') do
+      click_link 'Login'
+    end
 
     expect(current_path).to eq(login_path)
 
@@ -22,7 +24,7 @@ feature 'user visits root' do
     click_button "Login"
     expect(current_path).to eq(user_path(user))
 
-    within all('#nav-mobile').last do
+    within('#nav-mobile2') do
       expect(page).to have_link("Logout")
       expect(page).to have_link("Profile")
     end
@@ -35,7 +37,9 @@ feature 'user visits root' do
 
     visit '/'
 
-    click_link 'Profile'
+    within('#nav-mobile2') do
+      click_link 'Profile'
+    end
 
     expect(current_path).to eq(user_path(user))
   end
@@ -45,7 +49,9 @@ feature 'user visits root' do
 
     visit user_path(user)
 
-    click_link 'Logout'
+    within('#nav-mobile2') do
+      click_link 'Logout'
+    end
 
     expect(current_path).to eq(root_path)
     within('.alert-success') do
@@ -57,8 +63,9 @@ feature 'user visits root' do
 
     visit '/'
 
-    click_link 'Login'
-
+    within('#nav-mobile2') do
+      click_link 'Login'
+    end
     expect(current_path).to eq(login_path)
 
     fill_in "Name", with: "#{user.name}"


### PR DESCRIPTION
Modifies navbar such that on shrinking of the
window, the normal link buttons will disappear
and reveal two hamburger icons with dropdowns
containing the links that have been removed
due to resizing. Links remain functional in local testing.
Modifies user logs in spec and deactivated user logs
in spec to pass with new css present. All tests
currently passing.